### PR TITLE
Fix typo

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -182,7 +182,7 @@ let startExtemporeInTerminal = () => {
     _terminal.show(true); // show, but don't steal focus
 
     if (os.platform() === 'win32') {
-        _terminal.sendText(`cwd ${sharedir}`);
+        _terminal.sendText(`cd ${sharedir}`);
         _terminal.sendText(`./extempore.exe`);
     } else {
         _terminal.sendText(`cd ${sharedir}`);


### PR DESCRIPTION
When I installed this vscode extension, below error message was displayed.

```
Windows PowerShell
Copyright (C) Microsoft Corporation. All rights reserved.

PS C:\Users\minoru> cwd /Users/minoru/extempore
cwd : 用語 'cwd' は、コマンドレット、関数、スクリプト ファイル、または操作可能なプログラムの名前として認識されません。名前が正しく記述されていることを確
認し、パスが含まれている場合はそのパスが正しいことを確認してから、再試行してください。
発生場所 行:1 文字:1
+ cwd /Users/minoru/extempore
+ ~~~
   + CategoryInfo          : ObjectNotFound: (cwd:String) [], CommandNotFoundException
   + FullyQualifiedErrorId : CommandNotFoundException

PS C:\Users\minoru> ./extempore.exe
./extempore.exe : 用語 './extempore.exe' は、コマンドレット、関数、スクリプト ファイル、または操作可能なプログラムの名前として認識されません。名前が正し
く記述されていることを確認し、パスが含まれている場合はそのパスが正しいことを確認してから、再試行してください。
発生場所 行:1 文字:1
+ ./extempore.exe
+ ~~~~~~~~~~~~~~~
   + CategoryInfo          : ObjectNotFound: (./extempore.exe:String) [], CommandNotFoundException
   + FullyQualifiedErrorId : CommandNotFoundException

PS C:\Users\minoru>
```

This error message means that the `cwd` command can not be found. (I'm sorry to use Japanese)

Please review!

