### PR TITLE
Add links to sys:load params

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -131,6 +131,29 @@ export function activate(context: vscode.ExtensionContext) {
         });
         context.subscriptions.push(indentDisposable2);
     }
+
+    context.subscriptions.push(
+        vscode.languages.registerDocumentLinkProvider('extempore', {
+            provideDocumentLinks(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.DocumentLink[]> {
+                const results: vscode.DocumentLink[] = [];
+                for (const match of document.getText().matchAll(/(?<=\(sys:load ").+?\..+?(?=")/g)) {
+                    let path = match[0];
+                    // if it's not an absolute path
+                    if (!/^([\\\/~]|.+:[\\/])/.test(path)) {
+                        path = getExtemporePath()?.concat('/', path);
+                        if (!path) {
+                            continue;
+                        }
+                    }
+                    results.push(new vscode.DocumentLink(
+                        new vscode.Range(document.positionAt(match.index), document.positionAt(match.index + match[0].length)),
+                        vscode.Uri.file(path))
+                    );
+                }
+                return results;
+            }
+        })
+    );
 }
 
 export function dispose() {


### PR DESCRIPTION
This PR implements `vscode.DocumentLinkProvider`, adding links to paths passed to `sys:load`, making it possible to alt+click the param to open the file at that path. It works for the relative paths in the extempore folder, and for absolute paths on Windows. It should work for absolute paths on Mac and Linux too, but I have no way of testing it properly.